### PR TITLE
Only use LT_INIT once, and unconditionally 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,32 +124,23 @@ CP="cp -au"
 AC_SUBST(CURR_DIR)
 CURR_DIR=`pwd`
 
-AC_DEFUN([CONFIG_CYGWIN],[
+LT_INIT([win32-dll])
+case $build in
+  *-cygwin*)
     echo "Cygwin detected"
     SHAREDEXT=".dll"
     SHARED_LDFLAGS=" -shared "
     SEP=';'
-    LT_INIT([win32-dll])
     WIN32=yes
     AC_DEFINE([WIN32],[1],[Building on a win32 system (detected Cygwin).])
-])
-
-AC_DEFUN([CONFIG_MINGW],[
+    ;;
+  *-mingw*)
     echo "MinGW detected"
     SHAREDEXT=".dll"
     SHARED_LDFLAGS=" -shared "
     SEP=';'
-    LT_INIT([win32-dll])
     WIN32=yes
     AC_DEFINE([WIN32],[1],[Building on a win32 system (detected MinGW).])
-])
-
-case $build in
-  *-cygwin*)
-    CONFIG_CYGWIN
-    ;;
-  *-mingw*)
-    CONFIG_MINGW 
     ;;
   *-apple*)
     echo "Mac OS X detected"   
@@ -172,7 +163,6 @@ case $build in
     CXXFLAGS=" -fPIC $CXXFLAGS"
     ;;  
 esac
-LT_INIT
 
 AC_PREFIX_DEFAULT(["/usr/local/jmodelica"])
 


### PR DESCRIPTION
Using `LT_INIT` several times in one `configure.ac` file makes `AC_OUTPUT` produce a lot of error messages, and not work properly. So this changes `configure.ac` to only expand `LT_INIT` once.

This also tries to keep the per system differences together in one common large case statement instead of hiding some parts in `AC_DEFUN` macros but not others.

This keeps some things unfixed, e.g. `LT_INIT` already defines `PATH_SEPARATOR` to be either ";" or ":", but this configure.ac also defines `SEP` by itself. Similar things probably happen with `SHAREDEXT` and `SHARED_LDFLAGS`, but that is for some other time.

Fixes: https://github.com/JModelica/JModelica/issues/7