### PR TITLE
Jules preflight: paginate the source listing

### DIFF
--- a/.github/workflows/jules-preflight.yml
+++ b/.github/workflows/jules-preflight.yml
@@ -51,48 +51,81 @@ jobs:
         run: |
           set -euo pipefail
 
-          # -f so an HTTP error is a failure; the key goes through a header from
-          # an environment variable, never onto the command line.
-          if ! curl -fsS -H "x-goog-api-key: ${JULES_API_KEY}" \
-                 https://jules.googleapis.com/v1alpha/sources > sources.json; then
-            echo "::error::Could not list sources. The key may be invalid or revoked." >&2
-            exit 1
-          fi
+          # Paginated deliberately. GET /sources returns 30 per page by
+          # default, and an account with more connected repositories than that
+          # will not show the one you are looking for on page one. Reading a
+          # single page and concluding "not connected" is a false negative
+          # dressed as a finding - the instrument stopped early, the repository
+          # was not absent.
+          : > names.txt
+          token=""
+          pages=0
+          while : ; do
+            url="https://jules.googleapis.com/v1alpha/sources?pageSize=100"
+            if [ -n "${token}" ]; then
+              url="${url}&pageToken=${token}"
+            fi
 
-          count=$(jq '.sources | length // 0' sources.json)
-          echo "Jules can see ${count} source(s):"
-          jq -r '.sources[]?.name | "  " + .' sources.json
+            # -f so an HTTP error is a failure; the key goes through a header
+            # from an environment variable, never onto the command line.
+            if ! curl -fsS -H "x-goog-api-key: ${JULES_API_KEY}" "${url}" > page.json; then
+              echo "::error::Could not list sources. The key may be invalid or revoked." >&2
+              exit 1
+            fi
 
-          # What the action will construct, from action.yaml:
+            jq -r '.sources[]?.name' page.json >> names.txt
+            pages=$((pages + 1))
+            token=$(jq -r '.nextPageToken // empty' page.json)
+            [ -n "${token}" ] || break
+
+            if [ "${pages}" -ge 20 ]; then
+              echo "::warning::Stopped after 20 pages; the listing may be incomplete."
+              break
+            fi
+          done
+
+          count=$(wc -l < names.txt)
+          echo "Jules can see ${count} source(s) across ${pages} page(s)."
+
+          # What the action constructs, from its action.yaml:
           #   "source": "sources/github/\($repo_full_name)"
           expected="sources/github/${REPO}"
-          echo
           echo "google-labs-code/jules-action will address: ${expected}"
+          echo
 
-          if jq -e --arg e "${expected}" '.sources[]? | select(.name == $e)' \
-               sources.json > /dev/null; then
+          if grep -Fxq "${expected}" names.txt; then
             echo "::notice::Match. The action can address this repository."
-            verdict="The action's source name matches. Wiring is good."
+            verdict="\`${expected}\` is connected and addressable. Wiring is good."
+            status=0
           else
-            actual=$(jq -r --arg r "${REPO}" \
-                       '[.sources[]?.name | select(test("github"))] | .[0] // "none"' \
-                       sources.json)
-            echo "::error::No source named ${expected}." >&2
-            echo "::error::Closest match: ${actual}" >&2
-            echo "::error::If that is the hyphenated form, replace the action" >&2
-            echo "::error::with a direct POST to /v1alpha/sessions." >&2
-            verdict="**Mismatch.** The action builds \`${expected}\`, but the API returns \`${actual}\`. See doc/automation.md."
+            # A genuine near-match, not simply the first entry: look for this
+            # repository under any naming form, so the report distinguishes
+            # "not connected at all" from "connected under a different shape".
+            repo_name="${REPO#*/}"
+            related=$(grep -i -- "${repo_name}" names.txt || true)
+            if [ -n "${related}" ]; then
+              echo "::error::No source named ${expected}, but these look related:" >&2
+              echo "${related}" >&2
+              verdict="**Name mismatch.** The action builds \`${expected}\`, but the API lists:"$'\n\n```\n'"${related}"$'\n```\n\n'"Replace the action with a direct POST to /v1alpha/sessions. See doc/automation.md."
+            else
+              echo "::error::${REPO} is not connected to Jules." >&2
+              echo "::error::Installing the GitHub App is necessary but not sufficient:" >&2
+              echo "::error::a repository also has to be added as a codebase in the Jules" >&2
+              echo "::error::web app, and the API can only read sources, never create them." >&2
+              verdict="**Not connected.** \`${REPO}\` is not among the ${count} sources Jules can see. Add it at <https://jules.google.com> — sidebar, *codebases*, connect the repository. Having the GitHub App installed is necessary but not sufficient; the API cannot create a source."
+            fi
+            status=1
           fi
 
           {
             echo "## Jules preflight"
             echo
-            echo "Sources visible: ${count}"
+            echo "- API key: readable, and accepted by the API"
+            echo "- Sources visible: ${count}"
             echo
             echo "${verdict}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # Fail the run on a mismatch: a preflight that reports a problem and
-          # still goes green is not a preflight.
-          jq -e --arg e "${expected}" '.sources[]? | select(.name == $e)' \
-            sources.json > /dev/null
+          # A preflight that reports a problem and still goes green is not a
+          # preflight.
+          exit "${status}"


### PR DESCRIPTION
The first preflight run reported that `JModelica/JModelica` is not connected to Jules. That was a false negative produced by the check itself, not a finding.

`GET /v1alpha/sources` returns **30 per page** by default. The listing came back alphabetically ordered and was cut off mid-way through the `Foadsf/*` repositories, at `Foadsf/Exccel_COM` — so `JModelica/JModelica` could not have appeared regardless of whether it was connected. The instrument stopped early and the result was reported as an absence.

Paginating properly: **255 sources across 3 pages**, and `sources/github/JModelica/JModelica` is present.

## Two related fixes in the same step

- **The "closest match" was arbitrary.** It took jq's `.[0]` over everything matching `github`, so the first run offered `sources/github/AltElmer/ElmerGrid` as the closest match to `JModelica/JModelica`, which is meaningless. It now greps for the repository name, so a near-match is genuinely near.
- **The two failure modes are now distinguished**, because they call for different actions. *Connected under a different name shape* means the action's hardcoded `sources/github/OWNER/REPO` is wrong and must be replaced with a direct `POST /v1alpha/sessions`. *Not present at all* means the repository has to be added as a codebase in the Jules web app — installing the GitHub App is necessary but not sufficient, and the API can only read sources, never create them.

## Settled by this run

- The API key is valid and accepted by the API.
- This account's sources use the **slash form** `sources/github/OWNER/REPO`, matching what `google-labs-code/jules-action` builds. The quickstart-versus-reference discrepancy flagged in `doc/automation.md` is resolved in favour of the slash form for this account.
- The Jules GitHub App is installed org-wide with access to all repositories, and `JULES_API_KEY` is an organisation secret with `ALL` visibility, so it is readable from this public repository.

The pagination cap is 20 pages, and hitting it emits a warning — an incomplete listing should announce itself rather than reading as a clean negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLsmqp1y3fKjfteeFZRyJV
