### PR TITLE
jules-ci-fix: survive the action's internal checkout, and stop double-spending quota

### DIFF
--- a/.github/workflows/jules-ci-fix.yml
+++ b/.github/workflows/jules-ci-fix.yml
@@ -88,6 +88,13 @@ jobs:
           # Runs of this very workflow are the ledger, so no external state is
           # needed. A commit that broke CI and Docker at once must not produce
           # two sessions solving the same thing.
+          #
+          # Any conclusion except "skipped" counts as a handover. Matching only
+          # on "success" is wrong and was: a run that started a session and then
+          # failed in a later bookkeeping step is recorded as a failure, the
+          # guard does not see it, and the next trigger spends a second task on
+          # the identical problem. A run is "skipped" only when this guard
+          # already stopped it, which is the one case where no session started.
           if [ -n "${SHA:-}" ]; then
             seen=$(gh run list \
                      --workflow jules-ci-fix.yml \
@@ -95,7 +102,9 @@ jobs:
                      --json headSha,databaseId,conclusion \
                      --jq "[.[] | select(.headSha == \"${SHA}\" and
                                          .databaseId != ${GITHUB_RUN_ID} and
-                                         .conclusion == \"success\")] | length" \
+                                         .conclusion != null and
+                                         .conclusion != \"skipped\" and
+                                         .conclusion != \"cancelled\")] | length" \
                    2>/dev/null || echo 0)
             if [ "${seen}" -gt 0 ]; then
               proceed=false
@@ -112,7 +121,9 @@ jobs:
                       --json createdAt,conclusion,databaseId \
                       --jq "[.[] | select(.createdAt > \"${since}\" and
                                           .databaseId != ${GITHUB_RUN_ID} and
-                                          .conclusion == \"success\")] | length" \
+                                          .conclusion != null and
+                                          .conclusion != \"skipped\" and
+                                          .conclusion != \"cancelled\")] | length" \
                     2>/dev/null || echo 0)
             echo "Handovers in the last 24h: ${today} (max ${DAILY_MAX})"
             if [ "${today}" -ge "${DAILY_MAX}" ]; then
@@ -173,7 +184,17 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           else
             cat failures.txt
-            echo "found=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "found=true"
+              # Carried as an output, not left in a file. The Jules action runs
+              # actions/checkout internally, and checkout cleans the workspace
+              # (git clean -ffdx), so anything written here is gone by the time
+              # a later step looks for it.
+              delimiter="EOF_$(openssl rand -hex 12)"
+              echo "list<<${delimiter}"
+              cat failures.txt
+              echo "${delimiter}"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Assemble the prompt
@@ -267,6 +288,7 @@ jobs:
         env:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          FAILURES: ${{ steps.failures.outputs.list }}
         run: |
           {
             echo "### Handed to Jules"
@@ -275,5 +297,5 @@ jobs:
             echo
             echo "Failing run: ${RUN_URL}"
             echo
-            cat failures.txt
+            printf '%s\n' "${FAILURES}"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Two bugs in `jules-ci-fix.yml`, found by watching it run for real on the modernization branch. The second one cost quota.

## 1. The workspace disappears under the Jules action

"Record the handover" ran `cat failures.txt`, a file written two steps earlier in the same job. It failed on every run.

`google-labs-code/jules-action` is a **composite action whose first step is `actions/checkout@v5`**, and checkout cleans the workspace (`git clean -ffdx`). Anything written before the action is gone by the time a later step looks for it.

In itself this was cosmetic — Jules had already been handed the task successfully, and only the summary write failed. The list is now carried through a step output rather than a file.

## 2. …which then defeated the deduplication

Guard 1 exists so a commit that breaks CI *and* the container build produces **one** Jules session, not two. It matched runs of this workflow with `conclusion == "success"`.

A run that started a session and then failed in that bookkeeping step is recorded as a **failure**. The guard could not see it, so the next trigger treated the commit as unhandled and spent a second task on the identical problem.

That is precisely the loop the guards were written to prevent — defeated by an unrelated one-line bug two steps downstream. Observed on `feature/modernization-checkpoint`: three runs fired, one correctly skipped by the budget guard, two handed the same failure to Jules twice.

Both guards now count **any conclusion except `skipped` and `cancelled`** as a handover. A run is `skipped` only when the guards themselves stopped it, which is the one case where no session started. The daily budget gets the same treatment for the same reason.

## The general lesson

A guard keyed on *success* silently stops guarding the moment anything downstream of the guarded action can fail. Key it on **"did the thing happen"**, not on **"did the run end well"**.

## Verified

`actionlint` clean with shellcheck present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLsmqp1y3fKjfteeFZRyJV
