### PR TITLE
Fix the jules-ci-fix guards, and stop Windows CI claiming vcpkg installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,18 +205,39 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -f vcpkg.json ]; then
-            echo "Manifest found; vcpkg will install from vcpkg.json during configure."
-          else
+          if [ ! -f vcpkg.json ]; then
             echo "::notice::No vcpkg.json on this branch, so Sundials and BLAS are"
             echo "::notice::not available. Expect configure to fail."
+            exit 0
           fi
+          # A manifest on its own installs nothing. vcpkg reads vcpkg.json only
+          # when CMake is configured with its toolchain file, and this step used
+          # to print "vcpkg will install from vcpkg.json during configure" while
+          # the Configure step below ran a plain `cmake -S . -B build`. It never
+          # did install, and the job died at `find_library ... sundials_cvode`
+          # with a log that said the opposite of what had happened.
+          root="${VCPKG_INSTALLATION_ROOT:-}"
+          if [ -z "${root}" ] || [ ! -f "${root}/scripts/buildsystems/vcpkg.cmake" ]; then
+            echo "::error::vcpkg.json is present but VCPKG_INSTALLATION_ROOT does not" >&2
+            echo "::error::point at a usable vcpkg, so nothing would install it." >&2
+            exit 1
+          fi
+          echo "Manifest found; configuring with the vcpkg toolchain at ${root}."
+          {
+            echo "VCPKG_TOOLCHAIN=${root}/scripts/buildsystems/vcpkg.cmake"
+            echo "VCPKG_TARGET_TRIPLET=x64-windows"
+          } >> "$GITHUB_ENV"
 
       - name: Configure
         shell: bash
         run: |
           set -euo pipefail
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          args=(-S . -B build -DCMAKE_BUILD_TYPE=Release)
+          if [ -n "${VCPKG_TOOLCHAIN:-}" ]; then
+            args+=("-DCMAKE_TOOLCHAIN_FILE=${VCPKG_TOOLCHAIN}")
+            args+=("-DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}")
+          fi
+          cmake "${args[@]}"
 
       - name: Build
         shell: bash

--- a/.github/workflows/jules-ci-fix.yml
+++ b/.github/workflows/jules-ci-fix.yml
@@ -18,6 +18,16 @@ name: Jules — keep Actions green
 #
 # Set JULES_CI_FIX_ENABLED to 'false' to pause this entirely.
 
+# The run title carries the commit under investigation. This is not cosmetic:
+# guard 1 below reads it back. A workflow_run-triggered run is always attributed
+# to the default branch — `headSha` in the run list is master's tip, never the
+# commit that broke — so the run list cannot be used as a per-commit ledger
+# unless the commit is written somewhere the API will return. `displayTitle` is
+# that somewhere.
+run-name: >-
+  Jules — keep Actions green
+  (${{ github.event.workflow_run.head_sha || inputs.run_id }})
+
 on:
   workflow_run:
     workflows: ['CI', 'Container images', 'Release']
@@ -89,8 +99,16 @@ jobs:
           # needed. A commit that broke CI and Docker at once must not produce
           # two sessions solving the same thing.
           #
+          # Read the commit out of `displayTitle`, which `run-name:` above fills
+          # in. Matching on `headSha` was wrong and was: for a workflow_run
+          # trigger GitHub attributes the run to the *default branch*, so every
+          # row's headSha is master's tip and the comparison against the failing
+          # commit never matched. The guard silently passed every time. It cost
+          # three Jules sessions on 2026-09-07 — 12:25, 12:31 and 12:39 — for one
+          # branch and one set of failures.
+          #
           # Any conclusion except "skipped" counts as a handover. Matching only
-          # on "success" is wrong and was: a run that started a session and then
+          # on "success" is wrong too: a run that started a session and then
           # failed in a later bookkeeping step is recorded as a failure, the
           # guard does not see it, and the next trigger spends a second task on
           # the identical problem. A run is "skipped" only when this guard
@@ -99,8 +117,8 @@ jobs:
             seen=$(gh run list \
                      --workflow jules-ci-fix.yml \
                      --limit 60 \
-                     --json headSha,databaseId,conclusion \
-                     --jq "[.[] | select(.headSha == \"${SHA}\" and
+                     --json displayTitle,databaseId,conclusion \
+                     --jq "[.[] | select((.displayTitle | contains(\"${SHA}\")) and
                                          .databaseId != ${GITHUB_RUN_ID} and
                                          .conclusion != null and
                                          .conclusion != \"skipped\" and
@@ -133,14 +151,19 @@ jobs:
           fi
 
           # --- Guard 3: is Jules already working on this branch? --------------
+          # Scoped to the branch that broke. `baseRefName` was fetched but never
+          # tested, so an open Jules pull request anywhere in the repository
+          # blocked a handover for every other branch — the opposite failure to
+          # guard 1's, and just as silent.
           if [ "${proceed}" = "true" ] && [ -n "${BRANCH:-}" ]; then
             open=$(gh pr list --state open --limit 100 \
                      --json author,baseRefName \
-                     --jq "[.[] | select(.author.login | test(\"jules\"; \"i\"))] | length" \
+                     --jq "[.[] | select(.baseRefName == \"${BRANCH}\" and
+                                         (.author.login | test(\"jules\"; \"i\")))] | length" \
                    2>/dev/null || echo 0)
             if [ "${open}" -gt 0 ]; then
               proceed=false
-              reason="Jules already has ${open} open pull request(s); let them land first"
+              reason="Jules already has ${open} open pull request(s) against ${BRANCH}; let them land first"
             fi
           fi
 
@@ -260,10 +283,29 @@ jobs:
           in which case add a regression test proving the new behaviour is
           correct.
 
+          ## This session is unattended
+
+          Nothing started this run but a failing build, and no one is watching
+          the session waiting to answer you. A question asked here does not get
+          a reply — it ends the session with the work half done and the branch
+          no better than it was. So do not ask which approach to take, and do
+          not ask for permission or confirmation.
+
+          Decide instead. Pick the approach the evidence supports, say in one
+          line why you picked it over the alternative, and carry it through. If
+          a choice genuinely needs a maintainer — it changes the licence, it
+          deletes someone's branch, it needs a credential you do not have — do
+          the rest of the work first, then write the question into the pull
+          request description under a heading "Needs a decision", where a human
+          will actually see it.
+
           ## Pull request
 
           Open one pull request with the fix. Explain the root cause, the fix,
           and how you verified it. State plainly anything you could not verify.
+          Push it even when the work is incomplete: a branch with two of five
+          jobs fixed and an honest account of the other three is worth more
+          than an unpushed session.
           GUIDANCE
           } > prompt.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,12 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    # Both conventions. The only tag this repository has ever carried is `2.14`,
+    # inherited from upstream, and a `v*`-only filter would have skipped a `2.15`
+    # tagged the same way — silently, since a tag that matches nothing produces
+    # no run and therefore no failure to notice. `[0-9]*` is a glob, not a
+    # regex: it matches a tag whose first character is a digit.
+    tags: ['v*', '[0-9]*']
   workflow_dispatch:
     inputs:
       version:
@@ -108,17 +113,35 @@ jobs:
         if: steps.gate.outputs.run == 'true' && runner.os == 'Windows'
         shell: bash
         run: |
-          # vcpkg ships on the Windows runner image; the manifest drives it.
-          if [ -f vcpkg.json ]; then
-            echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> "$GITHUB_ENV"
+          set -euo pipefail
+          # vcpkg ships on the Windows runner image, but the manifest does not
+          # "drive it" on its own: vcpkg reads vcpkg.json only when CMake is
+          # configured with its toolchain file. Exporting VCPKG_ROOT alone,
+          # which is what this step used to do, installs nothing.
+          [ -f vcpkg.json ] || exit 0
+          root="${VCPKG_INSTALLATION_ROOT:-}"
+          if [ -z "${root}" ] || [ ! -f "${root}/scripts/buildsystems/vcpkg.cmake" ]; then
+            echo "::error::vcpkg.json is present but VCPKG_INSTALLATION_ROOT does not" >&2
+            echo "::error::point at a usable vcpkg, so nothing would install it." >&2
+            exit 1
           fi
+          {
+            echo "VCPKG_ROOT=${root}"
+            echo "VCPKG_TOOLCHAIN=${root}/scripts/buildsystems/vcpkg.cmake"
+            echo "VCPKG_TARGET_TRIPLET=x64-windows"
+          } >> "$GITHUB_ENV"
 
       - name: Build the runtime library
         if: steps.gate.outputs.run == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          args=(-S . -B build -DCMAKE_BUILD_TYPE=Release)
+          if [ -n "${VCPKG_TOOLCHAIN:-}" ]; then
+            args+=("-DCMAKE_TOOLCHAIN_FILE=${VCPKG_TOOLCHAIN}")
+            args+=("-DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}")
+          fi
+          cmake "${args[@]}"
           cmake --build build --config Release --parallel
 
       - name: Build the compiler

--- a/doc/automation.md
+++ b/doc/automation.md
@@ -131,10 +131,15 @@ working on the same problem in parallel. Three guards prevent that:
 1. **Deduplication by commit.** A commit whose failure has already been handed
    over is never handed over again, however many workflows it broke. This
    workflow's own run history is the ledger, so no external state is needed.
+   The commit is read out of each run's `displayTitle`, which the workflow's
+   `run-name:` fills in. It cannot be read out of `headSha`: a run triggered by
+   `workflow_run` is attributed to the *default branch*, so `headSha` is always
+   master's tip and never the commit that broke.
 2. **A daily budget.** At most `JULES_CI_FIX_DAILY_MAX` handovers per rolling
    24 hours, default 3.
-3. **Open-work check.** If Jules already has pull requests open, it is already
-   working; no second session starts until they land.
+3. **Open-work check.** If Jules already has a pull request open *against the
+   branch that broke*, it is already working; no second session starts until
+   that lands. Open work on other branches does not block a handover.
 
 ```sh
 gh variable set JULES_CI_FIX_DAILY_MAX --body 5
@@ -147,6 +152,13 @@ assertion, drop a failing platform from the matrix, or relax the artifact
 guard. Each of those turns a real signal into a false one, which is worse than
 the red build it started from. Where the honest answer is that a failure cannot
 be fixed in one session, it is told to push what it has and say what is left.
+
+The prompt also tells Jules that the session is unattended. That is not a
+courtesy — a session that ends on "which approach would you prefer?" leaves the
+branch exactly as red as it found it, and nobody is subscribed to answer. It is
+told to decide, justify the decision in one line, and put anything that
+genuinely needs a maintainer into the pull request description under a
+"Needs a decision" heading, where a human will see it.
 
 This is also why the CI jobs are gated on `detect` rather than exiting early:
 a build job that finds no build system, exits 0 and reports green would teach

--- a/doc/automation.md
+++ b/doc/automation.md
@@ -11,7 +11,7 @@ into pull requests — and what a maintainer has to do by hand to switch that on
 |---|---|---|
 | `ci.yml` | push, pull request | Repository hygiene, then real builds of the compiler, runtime and Python layers on Linux, macOS and Windows |
 | `docker.yml` | push, tag, pull request | Multi-architecture container images (`linux/amd64`, `linux/arm64`) to GHCR |
-| `release.yml` | tag `v*`, manual | Self-contained portable bundles per platform, attached to a GitHub release |
+| `release.yml` | tag `v*` or a tag starting with a digit, manual | Self-contained portable bundles per platform, attached to a GitHub release |
 | `jules-issue.yml` | `jules` label, `/jules` comment, manual | Hands one issue to Jules, which opens a pull request |
 | `jules-sweep.yml` | daily 04:00 UTC | Hands the oldest untouched issues to Jules, a few at a time |
 | `jules-branches.yml` | weekly Monday 05:00 UTC | Surveys every branch, opens draft pull requests, hands them to Jules to finish |
@@ -299,6 +299,14 @@ gh variable set ENABLE_EXTRA_RUNNERS --body true
 
 Set it once you have confirmed those runner images are available to this
 repository.
+
+`release.yml` has never run. That is the trigger working as specified, not a
+fault: it fires on a tag, and the repository carries exactly one tag — `2.14`,
+inherited from upstream and pushed long before this workflow existed. Nothing
+has been tagged since, and nothing has been dispatched by hand. It will stay
+that way until the compiler and runtime stages can succeed, because a release
+run that dies at the build produces no bundle and tells you nothing you did not
+already know from CI. Tag, or dispatch it, once `AGENTS.md` section 3 is clear.
 
 ## 6. Branch protection
 


### PR DESCRIPTION
Three checks that reported the opposite of what they measured. See the commit message for the full account.

### Why Jules did not take care of the two red runs on its own

It did start — three times. `jules-ci-fix.yml` handed the same branch and the same set of failures to Jules at 12:25, 12:31 and 12:39 UTC on 2026-09-07, spending the whole daily budget of three on one problem. Guard 1 exists to stop exactly that, and it had never worked: it compared the failing commit against `headSha` from `gh run list`, but a `workflow_run`-triggered run is attributed to the **default branch**, so every row's `headSha` is master's tip and the comparison can never match. The guard silently passed on every call since it was written.

Session [11904155372000811194](https://jules.google.com/session/11904155372000811194) then did real work — updated the Python 3 baseline, removed `verify_python.py`, reported a JastAdd fix — and ended on:

> Could you please advise if my approach for the C Runtime and E2E testing setup is on the right track, or if I should focus specifically on the `jmi_sundials_compat.{c,h}` shim implementation next?

Nobody is subscribed to that session, so the question has no reader and the branch stayed red with the work unpushed. The prompt now says the session is unattended, and tells Jules to decide, justify the choice in one line, and route anything that genuinely needs a maintainer into the pull request description under a "Needs a decision" heading.

### The three fixes

| Check | What it measured | What it reported |
|---|---|---|
| Guard 1, deduplication by commit | master's tip, every time | "this commit has not been handed over" — always |
| Guard 3, open-work check | fetched `baseRefName`, never tested it | any open Jules PR blocked every branch |
| Windows dependency install | nothing; no toolchain file was passed | "vcpkg will install from vcpkg.json during configure" |

The Windows one is the starkest: Configure ran a plain `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, vcpkg never saw the manifest, and the job died at `Could not find SUNDIALS_CVODE_LIB` directly beneath a line claiming the dependency had been handled.

### Verified

- Both jq filters exercised against synthetic run and pull-request lists, and they separate in both directions: guard 1 returns 2 for a commit already handed over (counting a run that started a session then failed in bookkeeping, excluding `skipped` and the current run) and 0 for a fresh commit; guard 3 returns 1 for the branch holding the Jules pull request and 0 for an unrelated branch.
- actionlint 1.7.7 — the version CI pins — with shellcheck on PATH reports nothing on the changed workflows. A deliberately broken control workflow dropped into the same tree was caught (SC2086 plus an undefined `github` property), so the linter was demonstrably running rather than merely quiet.

### Not verified

That vcpkg can build ipopt and sundials on a hosted Windows runner inside the job timeout. If it cannot, that is now a real result on the run page instead of a misleading one.

### Needs a decision

`AUTOMATION_TOKEN` is not set on this repository or the `JModelica` org. `jules-branches.yml` uses it to open the draft pull requests that get stale branches assessed; without it those pull requests are opened with `GITHUB_TOKEN`, and GitHub suppresses workflow runs triggered that way, so CI never starts on them and the whole point of the sweep is lost. Setting it needs a fine-grained PAT (`contents: read`, `pull-requests: write`) that only the owner should mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayx6WTBcNY653C3P8tNK5d
