### PR TITLE
Bill the Jules budget per commit, not per run

### DIFF
--- a/.github/workflows/jules-ci-fix.yml
+++ b/.github/workflows/jules-ci-fix.yml
@@ -131,19 +131,37 @@ jobs:
           fi
 
           # --- Guard 2: the daily budget --------------------------------------
+          # Counts distinct *commits*, not runs.
+          #
+          # A run in which guard 1 declines still concludes "success" — the
+          # triage job did its work and only `fix` was skipped — so counting
+          # runs charges the budget for handovers that never happened. On
+          # 2026-09-07 commit 9895559 produced one real session from the CI
+          # failure and one decline from the Container images failure, and the
+          # decline was billed as if it were a second session. Two failing
+          # workflows on one commit must cost one, which is the same thing
+          # guard 1 already enforces.
+          #
+          # Runs predating `run-name:` carry no commit in their title; they fall
+          # back to their own id so each still counts once.
           if [ "${proceed}" = "true" ]; then
             since=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
             today=$(gh run list \
                       --workflow jules-ci-fix.yml \
                       --limit 100 \
-                      --json createdAt,conclusion,databaseId \
-                      --jq "[.[] | select(.createdAt > \"${since}\" and
-                                          .databaseId != ${GITHUB_RUN_ID} and
-                                          .conclusion != null and
-                                          .conclusion != \"skipped\" and
-                                          .conclusion != \"cancelled\")] | length" \
+                      --json createdAt,conclusion,databaseId,displayTitle \
+                    | jq --arg since "${since}" \
+                         --argjson me "${GITHUB_RUN_ID}" '
+                        [ .[]
+                          | select(.createdAt > $since
+                                   and .databaseId != $me
+                                   and .conclusion != null
+                                   and (.conclusion | IN("skipped", "cancelled") | not))
+                          | (.displayTitle | [scan("[0-9a-f]{40}")] | first)
+                            // ("run-" + (.databaseId | tostring))
+                        ] | unique | length' \
                     2>/dev/null || echo 0)
-            echo "Handovers in the last 24h: ${today} (max ${DAILY_MAX})"
+            echo "Commits handed over in the last 24h: ${today} (max ${DAILY_MAX})"
             if [ "${today}" -ge "${DAILY_MAX}" ]; then
               proceed=false
               reason="daily budget of ${DAILY_MAX} handovers is spent"

--- a/doc/automation.md
+++ b/doc/automation.md
@@ -136,7 +136,11 @@ working on the same problem in parallel. Three guards prevent that:
    `workflow_run` is attributed to the *default branch*, so `headSha` is always
    master's tip and never the commit that broke.
 2. **A daily budget.** At most `JULES_CI_FIX_DAILY_MAX` handovers per rolling
-   24 hours, default 3.
+   24 hours, default 3. It counts distinct *commits*, not runs: a run in which
+   guard 1 declines still concludes `success`, because the triage job did its
+   work and only `fix` was skipped, so counting runs would charge the budget for
+   sessions that were never started. Two failing workflows on one commit cost
+   one, which is what guard 1 enforces anyway.
 3. **Open-work check.** If Jules already has a pull request open *against the
    branch that broke*, it is already working; no second session starts until
    that lands. Open work on other branches does not block a handover.


### PR DESCRIPTION
Found while verifying that the guard-1 fix from #33 actually works end to end. It does — and the verification turned up a second defect in the same guard set.

## Guard 1 holds

Commit \9895559\ broke both \CI\ and \Container images\. Same commit, two failing workflows:

| Run | Trigger | triage | fix | Session |
|---|---|---|---|---|
| 34136083053 | CI failure | success | **success** | [\10820617540207283171\](https://jules.google.com/session/10820617540207283171) |
| 34137654646 | Container images failure | success | **skipped** | none |

The second declined with \Not handing this failure over: commit 98955599 has already been handed to Jules\. This morning the identical shape produced two sessions on one problem.

## But the refusal is billed

A run where guard 1 declines concludes **\success\**, not \skipped\ — the triage job ran and succeeded, and only \ix\ was skipped. Guard 2 counted any run that was not skipped or cancelled, so the decline was charged to the daily budget as though a session had started. Those two runs cost two against a budget of five while only one session exists.

With the default budget of three, that is a third of the day's allowance spent on a decline, and it degrades further the more workflows one commit breaks — which is exactly the case guard 1 exists to handle.

Guard 2 now counts **distinct commits** rather than runs, collapsing a handover and every decline for the same commit into one. That is the unit guard 1 already works in. Runs predating \un-name:\ carry no commit in their title and fall back to their own id, so each still counts once.

## Verified

\jq\ against a fixture mirroring today's real ledger — the two runs on \9895559\, four earlier untitled runs, one \skipped\ run, and one run outside the 24-hour window:

\\\
counting runs             = 6
counting distinct commits = 5
\\\

The decline collapses into its handover; the skipped run, and the out-of-window run, are both excluded; the four untitled legacy runs still count once each through the id fallback. \ctionlint\ 1.7.7 reports nothing on the changed workflow.

## Not verified

The guard running in Actions — that needs a real failure after this lands. The step now prints \Commits handed over in the last 24h\, so the number it acted on is visible in the log rather than inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ayx6WTBcNY653C3P8tNK5d