### PR TITLE
Lowercase the GHCR image name, so the built image can be pushed

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   # The Dockerfile builds through CMake and Gradle. master still uses autotools
@@ -49,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       buildable: ${{ steps.check.outputs.buildable }}
+      image: ${{ steps.image.outputs.name }}
     steps:
       - uses: actions/checkout@v5
       - id: check
@@ -62,6 +62,20 @@ jobs:
           if [ "${buildable}" = "false" ]; then
             echo "::notice::No CMake/Gradle build on this ref; skipping the image build."
           fi
+
+      # OCI reference names must be lowercase, and this repository is
+      # `JModelica/JModelica`. Using ${{ github.repository }} verbatim built the
+      # image all the way through — compiler, runtime, Python layer, manifest —
+      # and then failed on the push with "invalid reference format: repository
+      # name (JModelica/JModelica) must be lowercase", throwing away the whole
+      # build. Lowercased here rather than hardcoded, so a fork under any name
+      # still publishes to its own namespace.
+      - id: image
+        run: |
+          set -euo pipefail
+          name="${GITHUB_REPOSITORY,,}"
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          echo "Image name: ${name}"
 
   build:
     name: ${{ matrix.platform }}
@@ -106,7 +120,7 @@ jobs:
           # pushing a tag per architecture would leave the tag pointing at
           # whichever build finished last.
           outputs: >-
-            type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+            type=image,name=${{ env.REGISTRY }}/${{ needs.detect.outputs.image }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           provenance: false
@@ -155,7 +169,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ needs.detect.outputs.image }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -174,7 +188,7 @@ jobs:
             $(printf "${REGISTRY}/${IMAGE_NAME}@sha256:%s " *)
         env:
           REGISTRY: ${{ env.REGISTRY }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ needs.detect.outputs.image }}
 
       - name: Inspect the published image
         run: |
@@ -182,4 +196,4 @@ jobs:
           version="$(jq -r '.labels["org.opencontainers.image.version"] // empty' <<< "${DOCKER_METADATA_OUTPUT_JSON}")"
           # Verify what was actually published rather than trusting the push.
           docker buildx imagetools inspect \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${version:-latest}"
+            "${{ env.REGISTRY }}/${{ needs.detect.outputs.image }}:${version:-latest}"


### PR DESCRIPTION
Lowercase the GHCR image name, so the built image can actually be pushed

On feature/modernization-checkpoint at 9895559 the container build finally
worked. linux/amd64 compiled the C runtime with CMake, built the compiler with
Gradle, built the Python wheel, exported every layer and wrote the manifest —
and then threw all of it away at the push:

    ERROR: failed to push ghcr.io/JModelica/JModelica: invalid reference format:
    repository name (JModelica/JModelica) must be lowercase

IMAGE_NAME was `${{ github.repository }}` verbatim, and this repository is
`JModelica/JModelica`. OCI reference names must be lowercase. The bug had never
been reachable before, because until this commit the build died long before the
push.

The name is now derived once in the `detect` job, which `build` and `manifest`
already depend on, and lowercased with `${GITHUB_REPOSITORY,,}`. Lowercased
rather than hardcoded to `jmodelica/jmodelica` so a fork under any name still
publishes into its own namespace. The workflow-level IMAGE_NAME is gone, so
there is one source of truth rather than two.

Verified:

  - `${GITHUB_REPOSITORY,,}` on bash 5.2: `JModelica/JModelica` becomes
    `jmodelica/jmodelica`, and an already-lowercase name is unchanged. The test
    carries a negative control that fails if the expansion is a no-op, and the
    control separated.
  - actionlint 1.7.7 reports nothing on the changed workflow. To check that this
    silence means something, a copy with `needs.detect.outputs.nosuchoutput` was
    linted: it was rejected with "property "nosuchoutput" is not defined in
    object type {buildable: string; image: string}" — which also confirms the
    new `image` output is declared and typed as the real file consumes it.
  - No `env.IMAGE_NAME` references remain.

Not verified here: an actual push to GHCR, which needs a run on a branch where
pushing is enabled. The `Inspect the published image` step already checks what
landed rather than trusting the push, so the next run on the checkpoint branch
will say plainly whether this worked.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ayx6WTBcNY653C3P8tNK5d
